### PR TITLE
Fix category links in post

### DIFF
--- a/_includes/footer-single.html
+++ b/_includes/footer-single.html
@@ -14,7 +14,7 @@
                     <ul>
                         {% for category in page.categories %}
                         <li>
-                            <a href='{{ "/category/" | append: page.categories.first | prepend: site.baseurl }}'>{{ category | capitalize }}</a>
+                            <a href='{{ "/category/" | append: category | prepend: site.baseurl }}'>{{ category | capitalize }}</a>
                             {% if forloop.last %}{% else %},{% endif %}
                         </li>
                         {% endfor %}


### PR DESCRIPTION
Links to categories under the post are always linking to the first category.

<img width="1236" alt="bildschirmfoto 2017-07-07 um 13 42 47" src="https://user-images.githubusercontent.com/287769/27956643-04135f7c-631b-11e7-94cb-a9c19904ab69.png">
