### PR TITLE
Fix capitalize name of authors

### DIFF
--- a/_layouts/category.html
+++ b/_layouts/category.html
@@ -16,7 +16,7 @@ layout: with-sidebar
         {{ post.excerpt | truncatewords: 28 }}
 
         <p class="meta">
-            <a href="{{ post.author_url | prepend: site.baseurl }}">{{ post.author_name | capitalize }}</a> in <a href='{{ "/category/" | append: post.categories.first | prepend: site.baseurl }}'>{{ post.categories.first | capitalize}}</a> <i class="link-spacer"></i> <i class="fa fa-bookmark"></i> {{ post.read_time }} minutes
+            <a href="{{ post.author_url | prepend: site.baseurl }}">{{ post.author_name }}</a> in <a href='{{ "/category/" | append: post.categories.first | prepend: site.baseurl }}'>{{ post.categories.first | capitalize}}</a> <i class="link-spacer"></i> <i class="fa fa-bookmark"></i> {{ post.read_time }} minutes
         </p>
 
         </div>


### PR DESCRIPTION
Enforced Capitalize lead to having last name always lowercased 

<img width="755" alt="bildschirmfoto 2017-07-07 um 14 08 46" src="https://user-images.githubusercontent.com/287769/27957242-dd216c76-631d-11e7-891b-b12c3da9a4a3.png">
