### PR TITLE
Assign category to a post

### DIFF
--- a/_posts/2017-07-01-build-custom-ui-extensions-in-contentful.md
+++ b/_posts/2017-07-01-build-custom-ui-extensions-in-contentful.md
@@ -2,6 +2,7 @@
 layout: post
 title:  "Build Custom UI Extensions for Contentful"
 date:   2017-07-01 02:00:00 +0200
+category: javascript
 author_name: Sergii Paryzhskyi
 author_url : /author/sergii_paryzhskyi
 author_avatar: sergii_paryzhskyi


### PR DESCRIPTION
Assign category to a contentful post in order to prevent the footer look like this:

<img width="615" alt="bildschirmfoto 2017-07-07 um 14 12 52" src="https://user-images.githubusercontent.com/287769/27957384-8e439754-631e-11e7-8f7e-a15679066348.png">


thx for reporting @Arturszott 