### PR TITLE
Bring back syntax-highlighting partial

### DIFF
--- a/_sass/_global.sass
+++ b/_sass/_global.sass
@@ -5,6 +5,7 @@
 @import "mixins"
 @import "type"
 @import "animate"
+@import "syntax-highlighting"
 @import "partials/bootstrap-components"
 
 // includes
@@ -60,7 +61,7 @@ body
 img
     max-width: 100%
 
-img.feature-image 
+img.feature-image
     margin-top: 20px
     margin-bottom: 20px
 

--- a/_sass/_syntax-highlighting.scss
+++ b/_sass/_syntax-highlighting.scss
@@ -3,7 +3,7 @@
  */
 .highlight {
     background: #fff;
-    @extend %vertical-rhythm;
+    margin-bottom: 30px;
 
     .c     { color: #998; font-style: italic } // Comment
     .err   { color: #a61717; background-color: #e3d2d2 } // Error


### PR DESCRIPTION
As this file was already there but just not used I included it to `global` partial which is imported in `main` sass file. I removed un existed variable and in place added manual px value which I think looks nice as it matched distance from top.