### PR TITLE
Update blog posts dates, so they represent when they were published

### DIFF
--- a/_posts/2017-11-16-haskell-learning-group-our-progress-and-updates.md
+++ b/_posts/2017-11-16-haskell-learning-group-our-progress-and-updates.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Haskell Learning Group: Our Progress and Updates"
-date: 2017-11-07 00:03:30 +0200
+date: 2017-11-16 00:12:00 +0200
 categories: haskell how-we-learn
 author_name: Sergii Paryzhskyi
 author_url : /author/sergii_paryzhskyi

--- a/_posts/2017-11-16-nix-in-practice-providing-dependencies.md
+++ b/_posts/2017-11-16-nix-in-practice-providing-dependencies.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Nix in Practice: Providing Dependencies"
-date: 2017-11-14 14:03:00 +0200
+date: 2017-11-16 14:03:00 +0200
 categories: nix
 author_name: Stefan Lau
 author_url : /author/stefanlau


### PR DESCRIPTION
For those who follows our rss along with other feeds, would be problematic to find a "new blogpost" that was published with the date when we started to write those blogposts and not with date of publishing