### PR TITLE
Revert "Update blog posts dates"

### DIFF
--- a/_posts/2017-11-07-haskell-learning-group-our-progress-and-updates.md
+++ b/_posts/2017-11-07-haskell-learning-group-our-progress-and-updates.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Haskell Learning Group: Our Progress and Updates"
-date: 2017-11-16 00:12:00 +0200
+date: 2017-11-07 00:03:30 +0200
 categories: haskell how-we-learn
 author_name: Sergii Paryzhskyi
 author_url : /author/sergii_paryzhskyi

--- a/_posts/2017-11-14-nix-in-practice-providing-dependencies.md
+++ b/_posts/2017-11-14-nix-in-practice-providing-dependencies.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title:  "Nix in Practice: Providing Dependencies"
-date: 2017-11-16 14:03:00 +0200
+date: 2017-11-14 14:03:00 +0200
 categories: nix
 author_name: Stefan Lau
 author_url : /author/stefanlau


### PR DESCRIPTION
As turned out - updating publish dates causes the url changes which can't be redirected, so the old urls are leading to 404 