### PR TITLE
Change typography

### DIFF
--- a/_includes/excerpt.html
+++ b/_includes/excerpt.html
@@ -1,2 +1,1 @@
-<br />
 {{ post.excerpt | truncatewords: 30 }}

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -39,7 +39,9 @@ layout: default
                 </p>
             </header>
 
-            {{ content }}
+            <div class="post-content">
+                {{ content }}
+            </div>
 
         </div><!-- main-content/col -->
     </div> <!--/row -->

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,7 +18,7 @@ layout: default
     <div class="row">
         <div class="col-xs-12 single-content">
             <header class="post-header">
-                <h1>{{ page.title }}</h1>
+                <h1 class='title'>{{ page.title }}</h1>
 
                 <p class="meta">
                     {% if page.author_name %}

--- a/_sass/_global.sass
+++ b/_sass/_global.sass
@@ -73,12 +73,16 @@ main
 
 
 a
-    color: $hc-blue
+    color: $text-color
     text-decoration: none
+    background-image: linear-gradient(to bottom,rgba(0,0,0,.68) 50%,rgba(0,0,0,0) 50%)
+    background-repeat: repeat-x
+    background-size: 2px .2em
+    background-position: 0 1.07em
 
     &:hover,
     &:active,
     &:focus
         text-decoration: none
         color: $text-color
-        border-bottom: solid 1px $hc-yellow
+        background-image: linear-gradient(to bottom,$hc-yellow 50%,rgba(0,0,0,0) 50%)

--- a/_sass/_global.sass
+++ b/_sass/_global.sass
@@ -73,16 +73,11 @@ main
 
 
 a
-    color: $text-color
+    color: $hc-blue
     text-decoration: none
-    background-image: linear-gradient(to bottom,rgba(0,0,0,.68) 50%,rgba(0,0,0,0) 50%)
-    background-repeat: repeat-x
-    background-size: 2px .2em
-    background-position: 0 1.07em
 
     &:hover,
     &:active,
     &:focus
         text-decoration: none
         color: $text-color
-        background-image: linear-gradient(to bottom,$hc-yellow 50%,rgba(0,0,0,0) 50%)

--- a/_sass/_type.sass
+++ b/_sass/_type.sass
@@ -22,7 +22,7 @@ input,
 select,
 textarea
     color: $text-color
-    font-family: $sans
+    font-family: $serif
 
 // Text rendering for titles only to insure no performance hit
 .post-preview,

--- a/_sass/_type.sass
+++ b/_sass/_type.sass
@@ -1,4 +1,4 @@
-@import url(http://fonts.googleapis.com/css?family=Fira+Sans:300,400,500,700|Droid+Serif:400,400italic,700|Playfair+Display)
+@import url(http://fonts.googleapis.com/css?family=Fira+Sans:300,400,500,700|Droid+Serif:300,400,400italic,700|Playfair+Display)
 
 $sans : 'Fira Sans', Helvetica, Arial, sans-serif
 $title : 'Playfair Display', serif
@@ -14,7 +14,7 @@ $hc-lightblue: #6bc5ec
 $base-color : $light-blue
 
 body
-    line-height: 1.45
+    line-height: 1.6
 
 body,
 button,
@@ -34,23 +34,19 @@ textarea
 
 .title
     font-family: $title
-    font-weight: 400
+    font-weight: 600
 
 p
     margin-bottom: 30px
-    font-weight: 300
-
-    +font-size(18)
+    font-weight: 400
 
     +breakpoint(sm)
-        +font-size(20)
+        +font-size(16)
 
     +breakpoint(md)
-        +font-size(21)
+        +font-size(18)
 a
     text-decoration: none
-    color: #fff
-    border-bottom: solid 1px #fAfafa
 
     &:hover,
     &:active
@@ -59,11 +55,6 @@ a
 
 em
     font-weight: 400
-
-h1,
-h2
-    font-weight: 700
-    font-family: $serif
 
 h1
     +font-size(38)
@@ -88,13 +79,12 @@ ul,
 ol
     margin-bottom: 20px
     padding-left: 20px
-    +font-size(18)
 
     +breakpoint(sm)
-        +font-size(20)
+        +font-size(16)
 
     +breakpoint(md)
-        +font-size(21)
+        +font-size(18)
 
     li
         margin: 5px 0

--- a/_sass/_type.sass
+++ b/_sass/_type.sass
@@ -1,6 +1,6 @@
-@import url(http://fonts.googleapis.com/css?family=Open+Sans:400,600,700,800|Droid+Serif:400,400italic,700|Playfair+Display)
+@import url(http://fonts.googleapis.com/css?family=Fira+Sans:300,400,500,700|Droid+Serif:400,400italic,700|Playfair+Display)
 
-$sans : 'Open Sans', Helvetica, Arial, sans-serif
+$sans : 'Fira Sans', Helvetica, Arial, sans-serif
 $title : 'Playfair Display', serif
 $serif : 'Droid Serif', serif
 
@@ -14,7 +14,7 @@ $hc-lightblue: #6bc5ec
 $base-color : $light-blue
 
 body
-    line-height: 1.65
+    line-height: 1.45
 
 body,
 button,
@@ -22,7 +22,7 @@ input,
 select,
 textarea
     color: $text-color
-    font-family: $serif
+    font-family: $sans
 
 // Text rendering for titles only to insure no performance hit
 .post-preview,
@@ -38,6 +38,8 @@ textarea
 
 p
     margin-bottom: 30px
+    font-weight: 300
+
     +font-size(18)
 
     +breakpoint(sm)
@@ -55,10 +57,13 @@ a
         color: #4761e2
         transition: all 400ms
 
+em
+    font-weight: 400
+
 h1,
 h2
     font-weight: 700
-    font-family: $sans
+    font-family: $serif
 
 h1
     +font-size(38)
@@ -74,7 +79,6 @@ h2
         +font-size(12)
 h3
     +font-size(26)
-
 
 b
     font-weight: 700

--- a/_sass/partials/_main-content.sass
+++ b/_sass/partials/_main-content.sass
@@ -54,12 +54,12 @@
 				&:hover
 					color: $light-grey
 		p
+			margin-bottom: 10px
 			+font-size(16)
 
 			+breakpoint(md)
 				+font-size(16)
 
-		.meta
 	&.author-page
 
 		.post-preview p

--- a/_sass/partials/_main-content.sass
+++ b/_sass/partials/_main-content.sass
@@ -16,7 +16,7 @@
 		margin-right: 30px
 		line-height: 40px
 		font-family: $sans
-		font-weight: 600
+		font-weight: 400
 		text-decoration: none
 		color: $hc-blue
 		margin-bottom: -2px
@@ -54,7 +54,6 @@
 				&:hover
 					color: $light-grey
 		p
-			font-family: $sans
 			+font-size(16)
 
 			+breakpoint(md)

--- a/_sass/partials/_main-content.sass
+++ b/_sass/partials/_main-content.sass
@@ -54,7 +54,7 @@
 				&:hover
 					color: $light-grey
 		p
-			font-family: $serif
+			font-family: $sans
 			+font-size(16)
 
 			+breakpoint(md)

--- a/_sass/partials/_post-content.sass
+++ b/_sass/partials/_post-content.sass
@@ -20,3 +20,20 @@ img.sizeup-onhover-image
   ol
     li
       padding: 10px 16px
+
+  a
+    color: $text-color
+    text-decoration: none
+    background-image: linear-gradient(to bottom,rgba(0,0,0,.68) 50%,rgba(0,0,0,0) 50%)
+    background-repeat: repeat-x
+    background-size: 2px .2em
+    background-position: 0 1.07em
+    border: none
+
+    &:hover,
+    &:active,
+    &:focus
+      border: none
+      text-decoration: none
+      color: $text-color
+      background-image: linear-gradient(to bottom,$hc-yellow 50%,rgba(0,0,0,0) 50%)

--- a/_sass/partials/_post-content.sass
+++ b/_sass/partials/_post-content.sass
@@ -15,8 +15,8 @@ img.sizeup-onhover-image
 .post-content
   ul
     li
-      padding: 10px 20px
+      padding: 10px 16px
 
   ol
     li
-      padding: 10px 20px
+      padding: 10px 16px

--- a/_sass/partials/_post-content.sass
+++ b/_sass/partials/_post-content.sass
@@ -11,3 +11,12 @@ img.sizeup-onhover-image
     transform-origin: left top
   &.origin-right-top:hover
     transform-origin: right top
+
+.post-content
+  ul
+    li
+      padding: 10px 20px
+
+  ol
+    li
+      padding: 10px 20px

--- a/_sass/partials/_shared.sass
+++ b/_sass/partials/_shared.sass
@@ -10,10 +10,8 @@
 
         &:hover,
         &:active
-            text-decoration: none
+            text-decoration: underline
             color: $text-color
-            border-bottom: 1px solid $light-grey
-
     i
         font-style: normal
 

--- a/_sass/partials/_single.sass
+++ b/_sass/partials/_single.sass
@@ -18,6 +18,13 @@
     +font-size(12)
     margin-bottom: 0
 
+    border-top: 1px solid #ccc
+    display: inline-block
+    padding-top: 10px
+    margin-top: 10px
+    font-family: $sans
+    font-weight: 300
+
     +breakpoint(sm)
         +font-size(16)
 

--- a/_sass/partials/_single.sass
+++ b/_sass/partials/_single.sass
@@ -72,7 +72,7 @@ blockquote
         +breakpoint(sm)
             +font-size(54)
     h2
-        +font-size(32)
+        +font-size(36)
         margin-top: 50px
         margin-bottom: 20px
 


### PR DESCRIPTION
We have already some posts, goal of this PR is to make them prettier (my feelings).

## What changed?

- Links are less eye catching, they are still there, decorated but do not get focus from the text itself.
- Headline font has changed to serif one that we have in blog title as well.
- More spacing around ordered and unordered lists. They have been unified.
- Text font was decreased a little
- Meta information like author, date and category is now separated with less importance.

**Before:** 
<img width="1671" alt="screen shot 2017-12-22 at 09 55 36" src="https://user-images.githubusercontent.com/2734152/34292218-46b778c2-e700-11e7-96ba-908dc7ef2db6.png">


**After:**
<img width="1670" alt="screen shot 2017-12-22 at 10 08 30" src="https://user-images.githubusercontent.com/2734152/34292221-4955b620-e700-11e7-9814-5da1359ba971.png">




