### PR TITLE
Update events for 2018

### DIFF
--- a/_data/events/2018.yml
+++ b/_data/events/2018.yml
@@ -1,4 +1,14 @@
 #
+# In house, at HolidayCheck
+#
+- name: Search Meetup Munich
+  start_datetime: 2018-01-18 18:30
+  url: https://www.meetup.com/Search-Meetup-Munich/events/246604008/?eventId=246604008
+  tags: meetup, search
+  location: HolidayCheck AG, Neumarkter Str. 61, Munich
+  comment: Andreas Neumann from Holidaycheck will talk about Test Driven Relevance Engineering
+
+#
 # Others
 #
 - name: JSConfEU 2018

--- a/_data/events/2018.yml
+++ b/_data/events/2018.yml
@@ -30,3 +30,7 @@
   start_datetime: 2018-01-16 23:59
   url: https://sessionize.com/wearedevelopers
   tags: CfP
+- name: enterJS 2018 - Call for Papers
+  start_datetime: 2018-01-14 23:59
+  url: https://www.enterjs.de/call-for-proposals-de
+  tags: CfP

--- a/_data/events/2018.yml
+++ b/_data/events/2018.yml
@@ -6,6 +6,13 @@
   end_datetime: 2018-06-03 18:00
   url: https://2018.jsconf.eu
   tags: conference, JavaScript
+  location: Berlin, Germany
+- name: JSConf Iceland 2018
+  start_datetime: 2018-03-01 10:00
+  end_datetime: 2018-06-02 18:00
+  url: https://2018.jsconf.is/
+  tags: conference, JavaScript
+  location: Reykjavik, Iceland
 - name: European Testing Conference 2018
   start_datetime: 2018-02-19 10:00
   end_datetime: 2018-02-20 18:00
@@ -18,6 +25,16 @@
   location: Vienna, Austria, The Austria Center Vienna
   url: https://www.wearedevelopers.com/
   tags: conference, developers
+
+#
+# Unconfs
+#
+- name: CodeFreeze 2018
+  start_datetime: 2018-01-15 10:00
+  end_datetime: 2018-01-17 18:00
+  location: Kiilopää, Inari, Finland
+  url: http://www.codefreeze.fi/
+  tags: unconference
 
 #
 # CfPs

--- a/_data/events/2018.yml
+++ b/_data/events/2018.yml
@@ -7,24 +7,28 @@
   url: https://2018.jsconf.eu
   tags: conference, JavaScript
   location: Berlin, Germany
+  twitter: jsconfeu
 - name: JSConf Iceland 2018
   start_datetime: 2018-03-01 10:00
   end_datetime: 2018-06-02 18:00
   url: https://2018.jsconf.is/
   tags: conference, JavaScript
   location: Reykjavik, Iceland
+  twitter: jsconfis
 - name: European Testing Conference 2018
   start_datetime: 2018-02-19 10:00
   end_datetime: 2018-02-20 18:00
   url: http://europeantestingconference.eu/2018/
   location: Amsterdam Arena, Amsterdam, Netherlands
   tags: conference, testing
+  twitter: EuroTestingConf
 - name: WeAreDevelopers 2018
   start_datetime: 2018-05-16 10:00
   end_datetime: 2018-05-18 18:00
   location: Vienna, Austria, The Austria Center Vienna
   url: https://www.wearedevelopers.com/
   tags: conference, developers
+  twitter: wearedevs
 - name: Nordic.js 2018
   start_datetime: 2018-09-06 10:00
   end_datetime: 2018-09-07 18:00

--- a/_data/events/2018.yml
+++ b/_data/events/2018.yml
@@ -25,6 +25,13 @@
   location: Vienna, Austria, The Austria Center Vienna
   url: https://www.wearedevelopers.com/
   tags: conference, developers
+- name: Nordic.js 2018
+  start_datetime: 2018-09-06 10:00
+  end_datetime: 2018-09-07 18:00
+  location: Stockholm, Sweden
+  url: http://nordicjs.com/
+  tags: conference, JavaScript
+  twitter: nordicjs
 
 #
 # Unconfs
@@ -50,4 +57,8 @@
 - name: enterJS 2018 - Call for Papers
   start_datetime: 2018-01-14 23:59
   url: https://www.enterjs.de/call-for-proposals-de
+  tags: CfP
+- name: Nordic.js 2018 - Call for Papers
+  start_datetime: 2018-09-06 00:00
+  url: http://cfp.nordicjs.com/
   tags: CfP

--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -3,11 +3,11 @@ layout: with-sidebar
 ---
 
 <div class="sub-nav events">
-    <a href="#" class="select-2017 active">Events in 2017</a>
-    <a href="#" class="select-2018">in 2018</a>
+    <a href="#" class="select-2018 active">Events in 2018</a>
+    <a href="#" class="select-2017">in 2017</a>
 </div>
 
-{% assign years = "2017 2018" | split: " " %}
+{% assign years = "2018 2017" | split: " " %}
 {% for cur_year in years %}
 <div class="events-{{cur_year}} animated fadeIn {% if forloop.first == false %}hide{% endif %}" id="{{cur_year}}">
   {% assign all_events = site.data.events[cur_year] %}

--- a/_layouts/events.html
+++ b/_layouts/events.html
@@ -38,6 +38,11 @@ layout: with-sidebar
       {% else %}
         {{ event.name }}
       {% endif %}
+
+      {% if event.twitter %}
+        <a href="https://twitter.com/{{ event.twitter }}" class="fa fa-twitter"></a>
+      {% endif %}
+
       {% if event.posts %}
         - read about it:
         {% for post in event.posts %}


### PR DESCRIPTION
- show the 2018 events first when you come on the page and
- add some more events
  
the old one was
<img width="644" alt="bildschirmfoto 2018-01-07 um 13 24 04" src="https://user-images.githubusercontent.com/113427/34649372-20a75908-f3ae-11e7-8d83-53cf653fcdb1.png">

this PR makes the page look like this:
<img width="608" alt="bildschirmfoto 2018-01-07 um 13 24 12" src="https://user-images.githubusercontent.com/113427/34649375-29d999dc-f3ae-11e7-8376-9f946e54fdb6.png">

its not automated with the latest year, etc. yet ...

