### PR TITLE
nix-shell: serve future posts

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -28,6 +28,6 @@ in
     '';
 
     shellHook = ''
-      JEKYLL_ENV=local jekyll serve --config _config.yml,_config_local.yml --watch
+      JEKYLL_ENV=local jekyll serve --config _config.yml,_config_local.yml --watch --future
     '';
   }


### PR DESCRIPTION
Start jekyll with `--future` will also display posts with future dates