### PR TITLE
Escape " characters

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -4,20 +4,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <title>{{ site.title }} | {% if page.title %}{{ page.title }}{% endif %}</title>
-    <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 155 }}{% else %}{{ site.description }}{% endif %}">
+    <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 155 | replace:'"','&quot;' }}{% else %}{{ site.description }}{% endif %}">
 
     {% if page.layout == "post" %}
 
     <!-- Google data -->
     <meta itemprop="name" content="{% if page.title %}{{ page.title }}{% endif %}">
-    <meta itemprop="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 155 }}{% else %}{{ site.description }}{% endif %}">
+    <meta itemprop="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 155 | replace:'"','&quot;' }}{% else %}{{ site.description }}{% endif %}">
     <meta itemprop="image" content="{{ "/img/" | append: page.feature_image | prepend: site.baseurl | prepend: site.url }}">
 
     <!-- Twitter Card data -->
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@HolidayCheckLab">
     <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% endif %}">
-    <meta name="twitter:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 200 }}{% else %}{{ site.description }}{% endif %}">
+    <meta name="twitter:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 200 | replace:'"','&quot;' }}{% else %}{{ site.description }}{% endif %}">
     <meta name="twitter:creator" content="@HolidayCheckLab">
     <!-- Twitter summary card with large image must be at least 280x150px -->
     <meta name="twitter:image:src" content="{{ "/img/" | append: page.feature_image | prepend: site.baseurl | prepend: site.url }}">
@@ -27,7 +27,7 @@
     <meta property="og:type" content="article" />
     <meta property="og:url" content="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}" />
     <meta property="og:image" content="{{ "/img/" | append: page.feature_image | prepend: site.baseurl | prepend: site.url }}" />
-    <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 155 }}{% else %}{{ site.description }}{% endif %}" />
+    <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 155 | replace:'"','&quot;' }}{% else %}{{ site.description }}{% endif %}" />
     <meta property="og:site_name" content="{{ site.title }}" />
     <meta property="article:published_time" content="{{ page.date | date: "%Y-%m-%dT00:00:00+01:00" }}" />
     <meta property="article:section" content="{{ page.categories[0] }}" />

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -29,7 +29,7 @@ layout: default
                     </span>
                     <span itemprop="mainEntityOfPage url" content="{{ page.url | prepend: site.baseurl | prepend: site.url }}"></span>
                     <span itemprop="image" content='{{"/img/" | append: page.feature_image | prepend: site.baseurl | prepend: site.url }}'></span>
-                    <span itemprop="headline" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 110 }}"></span>
+                    <span itemprop="headline" content="{{ page.excerpt | strip_html | strip_newlines | truncate: 110 | replace:'"','&quot;' }}"></span>
                     {% include authors.html post=page %}
 
                     in <a href='{{ "/category/" | append: page.categories.first | prepend: site.baseurl }}'>{{ page.categories[0] | capitalize | replace: "-", " " }}</a>


### PR DESCRIPTION
Fixes wrong rendering of content when strings contain `"` character and are used in attributes, e.g. `... description="Title is "The title"." ...` 