### PR TITLE
Use protocol-related URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -21,7 +21,11 @@ description: > # this means to ignore newlines until "baseurl:"
   If you like stuff you see here, make sure to get in touch with us, we are
   always looking for pationate new colleagues!
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://techblog.holidaycheck.com" # the base hostname & protocol for your site, e.g. http://example.com
+
+# This is an anti-pattern: https://www.paulirish.com/2010/the-protocol-relative-url/
+# It should be used until the blog's domain is redirecting to https (not happening now)
+url: "//techblog.holidaycheck.com"
+
 twitter_username: holidaychecklab
 github_username:  holidaycheck
 permalink: post/:year/:month/:day/:title


### PR DESCRIPTION
Till the domain will redirect to https (by default), this trick
needs to be used to load all assets from same protocol.

Right now, if you enter the blog using secured connection (https)
some resources will be blocked, as the base URL is hardcoded
and uses http.

This is considered anti-pattern, and when the redirection to https
will be done permanently, this value (for url in config) should be
hardcoded to https.

See: https://www.paulirish.com/2010/the-protocol-relative-url/