### PR TITLE
Replace outdated GitHub URL for Jobs with official URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -30,7 +30,7 @@ permalink: post/:year/:month/:day/:title
 nav_list:
   Home : ['Home', '/', 'fa-home']
   Events : ['Events', '/events', 'fa-calendar']
-  Jobs : ['Jobs', 'http://github.com/holidaycheck/jobs', 'fa-heart']
+  Jobs : ['Jobs', 'https://www.holidaycheckgroup.com/jobs/it-engineering/?lang=en', 'fa-heart']
   Imprint : ['Imprint', 'https://www.holidaycheck.de/impressum', 'fa-envelope']
   About : ['About', '/about', 'fa-info-circle']
   Twitter : ['Twitter', 'http://twitter.com/holidaychecklab', 'fa-twitter']

--- a/about.md
+++ b/about.md
@@ -11,4 +11,4 @@ If you like stuff you see here, make sure to [get in touch with us][contact],
 [we are always looking for passionate new colleagues][apply]!
 
 [contact]: https://twitter.com/holidaychecklab
-[apply]: https://github.com/holidaycheck/jobs
+[apply]: https://www.holidaycheckgroup.com/jobs/it-engineering/?lang=en


### PR DESCRIPTION
We still have links to our deprecated GitHub jobs page in the main menu and on the About page. This pull request replaces those URLs with the correct URL for our official job page.